### PR TITLE
Use OpenVPN `--cd` option to allow writing simpler configuration files.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ COPY bin/update-resolv-conf /etc/openvpn/
 
 VOLUME ["/vpn"]
 
-ENTRYPOINT [ "openvpn", "--config", "/vpn/vpn.conf", "--script-security", "2", "--up", "/etc/openvpn/update-resolv-conf", "--down", "/etc/openvpn/update-resolv-conf" ]
+ENTRYPOINT [ "openvpn", "--cd", "/vpn", "--config", "/vpn/vpn.conf", "--script-security", "2", "--up", "/etc/openvpn/update-resolv-conf", "--down", "/etc/openvpn/update-resolv-conf" ]

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ If you care about the times shown in the logs you can use
 
 In order to work you must provide a VPN configuration and certificate.
 Put your VPN configuration in /some/path/vpn.conf.
-If your certificate is not embedded, place it in /some/path/some_cert_file
-and reference /vpn/some_cert_file in your vpn.conf.
+If your certificate is not embedded, place it in `/some/path/some_cert_file`
+and reference `some_cert_file` in your `vpn.conf`.
 
     docker run --cap-add=NET_ADMIN --device /dev/net/tun --name openvpn \
                 -v /some/path:/vpn -d troyc/openvpn 


### PR DESCRIPTION
Previously, referencing an external CA or other file required to use the
`/vpn/` prefix for these files on the OpenVPN config. Now it's possible to
drop that prefix which allows to test the config file on the host without
starting a container by simply issuing `openvpn vpn.conf`.
